### PR TITLE
Work around issue with touches not ending properly

### DIFF
--- a/SpriteKit-Components/SKComponentNode.m
+++ b/SpriteKit-Components/SKComponentNode.m
@@ -254,6 +254,10 @@ void skc_applyOnExit(SKNode* node) {
         }
     }
 
+    if (!_touchState.touch) {
+        isFingerDown = NO;
+    }
+
     for (UITouch *touch in touches) {
         if (!isFingerDown) {
             isFingerDown = YES;


### PR DESCRIPTION
This isn't a great fix, I'm not sure exactly where the bug is, but I thought I'd include by workaround for discussion.

I'm trying to use code similar to the Touch Interaction example to make two independently draggable nodes. I noticed that when trying to move both at the same time using two touches that sometimes one or another would get "stuck". It turned out that sometimes isFingerDown would be set, so touchesBegan would not start a touch, but _touchState.touch would be nil, so touchesMoved wouldn't fire updates. (Changing the touch property to be a strong reference would stop the touch being released, putting a breakpoint in touchesMoved would show that it was still set to the old "ended" touch, stopping further calls to the moved component callback.)

I've noticed that when I start two touches at once, sometimes one touch is ignored, and both draggable nodes follow the same touch. I'm not sure how that happens either. My guess is that when a draggable gets stuck, that its drag end callback gets c

Multi-touch isn't terribly important for my app, so this workaround for the "stuck" draggables is sufficient, but I'd quite like to know what the correct fix is. I'll post back if I come across a solution.
