### PR TITLE
Fixed bug where node was not unregistered on exit from scene

### DIFF
--- a/SpriteKit-Components/SKComponentNode.m
+++ b/SpriteKit-Components/SKComponentNode.m
@@ -153,7 +153,7 @@
 
     // unregister self with scene
     SKComponentScene* scene = SKComponentSceneForNode(self);
-    [scene registerComponentNode:self];
+    [scene unregisterComponentNode:self];
 
     // perform onExit for all components
     for (id<SKComponent> component in components) {


### PR DESCRIPTION
I found that update continued to be called for nodes that had been removed from the scene after having called removeFromParent on the node.  I think it was originally a typo so I have updated registerComponentNode to unregisterComponentNode which corrects this behaviour and prevents update from being called after the node has been removed from the scene.
